### PR TITLE
unknown encoding: utf8mb3

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -240,6 +240,11 @@ class RowsEvent(BinLogEvent):
 
     @staticmethod
     def charset_to_encoding(name):
+        # there is no charset for utf8mb3, and this break decoding.
+        # Mysql has deprecated utf8mb3, and in mariadb utf8 is an alias for utf8mb3
+        if name == 'utf8mb3':
+            name = 'utf8'
+
         charset = charset_by_name(name)
         return charset.encoding if charset else name
 


### PR DESCRIPTION
intercept utf8mb3 charset and replace with its alias utf8 to avoid decoding failure